### PR TITLE
htable: close parentheses on error description inside htable_rpc_delete

### DIFF
--- a/src/modules/htable/htable.c
+++ b/src/modules/htable/htable.c
@@ -1304,7 +1304,7 @@ static void htable_rpc_delete(rpc_t* rpc, void* c) {
 	ht_t *ht;
 
 	if (rpc->scan(c, "SS", &htname, &keyname) < 2) {
-		rpc->fault(c, 500, "Not enough parameters (htable name & key name");
+		rpc->fault(c, 500, "Not enough parameters (htable name & key name)");
 		return;
 	}
 	ht = ht_get_table(&htname);


### PR DESCRIPTION
htable: Close parentheses on error description inside htable_rpc_delete function.

